### PR TITLE
Update tinyxml2 to be under cv namespace

### DIFF
--- a/modules/datasets/src/or_pascal.cpp
+++ b/modules/datasets/src/or_pascal.cpp
@@ -57,7 +57,7 @@ namespace datasets
 {
 
 using namespace std;
-using namespace tinyxml2;
+using namespace cv::tinyxml2;
 
 class OR_pascalImp CV_FINAL : public OR_pascal
 {

--- a/modules/datasets/src/tinyxml2/tinyxml2.cpp
+++ b/modules/datasets/src/tinyxml2/tinyxml2.cpp
@@ -61,6 +61,8 @@ static const unsigned char TIXML_UTF_LEAD_2 = 0xbfU;
         }										\
     }
 
+namespace cv
+{
 namespace tinyxml2
 {
 
@@ -2201,3 +2203,4 @@ bool XMLPrinter::Visit( const XMLUnknown& unknown )
 }
 
 }   // namespace tinyxml2
+}   // namespace cv

--- a/modules/datasets/src/tinyxml2/tinyxml2.h
+++ b/modules/datasets/src/tinyxml2/tinyxml2.h
@@ -126,6 +126,8 @@ static const int TIXML2_MAJOR_VERSION = 2;
 static const int TIXML2_MINOR_VERSION = 1;
 static const int TIXML2_PATCH_VERSION = 0;
 
+namespace cv
+{
 namespace tinyxml2
 {
 class XMLDocument;
@@ -2071,6 +2073,7 @@ private:
 
 
 }	// tinyxml2
+}	// cv
 
 #if defined(_MSC_VER)
 #   pragma warning(pop)

--- a/modules/datasets/src/tr_svt.cpp
+++ b/modules/datasets/src/tr_svt.cpp
@@ -57,7 +57,7 @@ namespace datasets
 {
 
 using namespace std;
-using namespace tinyxml2;
+using namespace cv::tinyxml2;
 
 class TR_svtImp CV_FINAL : public TR_svt
 {


### PR DESCRIPTION
Cherry-pick #1 to version 4.3.0.

Rework tinyxml2 in this module to have namespace cv::tinyxml2
instead of just tinyxml2, so will not clash with other versions
of tinyxml2 at linkage time.

(cherry picked from commit 89f551f6a8f3fae20433b1cbc8309cf839446a95)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under OpenCV (BSD) License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
